### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-AntoIO	    KEYWORD1
+AntoIO	KEYWORD1
 AntoHTTP	KEYWORD1
 AntoMQTT	KEYWORD1
 AntoWiFi	KEYWORD1
@@ -15,38 +15,38 @@ AntoWiFi	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-smartconfig	    KEYWORD2
+smartconfig	KEYWORD2
 
 digitalUpdate	KEYWORD2
 analogUpdate	KEYWORD2
 stringUpdate	KEYWORD2
-digitalGet	    KEYWORD2
-analogGet	    KEYWORD2
-stringGet	    KEYWORD2
-httpRequest	    KEYWORD2
-request	        KEYWORD2
+digitalGet	KEYWORD2
+analogGet	KEYWORD2
+stringGet	KEYWORD2
+httpRequest	KEYWORD2
+request	KEYWORD2
 removeHeader	KEYWORD2
-setHost	        KEYWORD2
+setHost	KEYWORD2
 
-getVersion	    KEYWORD2
-begin	        KEYWORD2
+getVersion	KEYWORD2
+begin	KEYWORD2
 
-loop	        KEYWORD2
-onData	        KEYWORD2
-disconnect	    KEYWORD2
-isConnected	    KEYWORD2
-connect	        KEYWORD2
-pub	            KEYWORD2
-sub	            KEYWORD2
-service	        KEYWORD2
+loop	KEYWORD2
+onData	KEYWORD2
+disconnect	KEYWORD2
+isConnected	KEYWORD2
+connect	KEYWORD2
+pub	KEYWORD2
+sub	KEYWORD2
+service	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-ANTO_MQTT_PORT	    LITERAL1
-ANTO_MQTTS_PORT	    LITERAL1
+ANTO_MQTT_PORT	LITERAL1
+ANTO_MQTTS_PORT	LITERAL1
 ANTO_RAND_STR_LEN	LITERAL1
-ANTO_GET	        LITERAL1
-ANTO_SET	        LITERAL1
+ANTO_GET	LITERAL1
+ANTO_SET	LITERAL1
 ANTO_VER	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. Leading spaces on a keyword identifier causes it to not be recognized by the Arduino IDE. On Arduino IDE 1.6.5 and newer an unrecognized keyword identifier causes the default editor.function.style highlighting to be used (as with KEYWORD2, KEYWORD3, LITERAL2).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords